### PR TITLE
HOTFIX: remove quotation marks from param values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* [PR-2] (https://github.com/AGH-CEAI/robotiq_hande_description/pull/2) - Remove question marks from param values
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-* [PR-2] (https://github.com/AGH-CEAI/robotiq_hande_description/pull/2) - Remove question marks from param values
+* [PR-2] (https://github.com/AGH-CEAI/robotiq_hande_description/pull/2) - Removed unnecessary quotation marks from parameter values.
 
 ### Security

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -9,14 +9,14 @@
 
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
-          <param name="grip_pos_min">"${grip_pos_min}"</param>
-          <param name="grip_pos_max">"${grip_pos_max}"</param>
-          <param name="tty">"${tty}"</param>
-          <param name="baudrate">"${baudrate}"</param>
-          <param name="parity">"${parity}"</param>
-          <param name="data_bits">"${data_bits}"</param>
-          <param name="stop_bit">"${stop_bit}"</param>
-          <param name="slave_id">"${slave_id}"</param>
+          <param name="grip_pos_min">${grip_pos_min}</param>
+          <param name="grip_pos_max">${grip_pos_max}</param>
+          <param name="tty">${tty}</param>
+          <param name="baudrate">${baudrate}</param>
+          <param name="parity">${parity}</param>
+          <param name="data_bits">${data_bits}</param>
+          <param name="stop_bit">${stop_bit}</param>
+          <param name="slave_id">${slave_id}</param>
         </xacro:unless>
       </hardware>
 


### PR DESCRIPTION
## Description
We need parameters parsed as strings, not strings in quotation marks.

## Motivation and context
Libs have problems with parsing values to double or int.

## How has this been tested?
Building a project.

## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---
Clickup task: [869619b4u](https://app.clickup.com/t/869619b4u)
