### PR TITLE
Parametrize mouting transform for the gripper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_description/pull/11) - Parametrized link transform for the gripper.
 * [PR-1](https://github.com/AGH-CEAI/robotiq_hande_description/pull/1) - Configuration parameters for ModbusRTU.
-* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_description/pull/11) - Custom mounting transform for gripper.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * [PR-1](https://github.com/AGH-CEAI/robotiq_hande_description/pull/1) - Configuration parameters for ModbusRTU.
+* [PR-11](https://github.com/AGH-CEAI/robotiq_hande_description/pull/11) - Custom mounting transform for gripper.
 
 ### Changed
 

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -7,8 +7,8 @@
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.ros2_control.xacro"/>
   <xacro:include filename="$(find robotiq_hande_description)/urdf/cylinder_inertial.xacro"/>
 
-  <xacro:macro 
-    name="robotiq_hande_gripper" 
+  <xacro:macro
+    name="robotiq_hande_gripper"
     params="name
             prefix
             parent
@@ -24,8 +24,7 @@
             coupler_mass:=0.119
             xyz:='0 0 0'
             rpy:='0 0 0'"
-  > 
-
+  >
     <!-- ros2_control parameters  -->
     <xacro:robotiq_hande_ros2_control
       name="${name}"

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -7,7 +7,24 @@
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.ros2_control.xacro"/>
   <xacro:include filename="$(find robotiq_hande_description)/urdf/cylinder_inertial.xacro"/>
 
-  <xacro:macro name="robotiq_hande_gripper" params="name prefix parent grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id use_fake_hardware coupler_mass:=0.119">
+  <xacro:macro 
+    name="robotiq_hande_gripper" 
+    params="name
+            prefix
+            parent
+            grip_pos_min
+            grip_pos_max
+            tty
+            baudrate
+            parity
+            data_bits
+            stop_bit
+            slave_id
+            use_fake_hardware
+            coupler_mass:=0.119
+            xyz:='0 0 0'
+            rpy:='0 0 0'">
+
     <!-- ros2_control parameters  -->
     <xacro:robotiq_hande_ros2_control
       name="${name}"
@@ -36,7 +53,7 @@
     <xacro:arg name="hande_radius" default="0.0375"/>
 
     <joint name="${prefix}robotiq_hande_coupler_joint" type="fixed">
-      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <origin xyz="${xyz}" rpy="${rpy}"/>
       <parent link="${parent}"/>
       <child link="${prefix}robotiq_hande_coupler"/>
     </joint>

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -24,7 +24,7 @@
             coupler_mass:=0.119
             xyz:='0 0 0'
             rpy:='0 0 0'"
-    >
+  > 
 
     <!-- ros2_control parameters  -->
     <xacro:robotiq_hande_ros2_control

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -23,7 +23,8 @@
             use_fake_hardware
             coupler_mass:=0.119
             xyz:='0 0 0'
-            rpy:='0 0 0'">
+            rpy:='0 0 0'"
+    >
 
     <!-- ros2_control parameters  -->
     <xacro:robotiq_hande_ros2_control


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This PR makes the relative pose between the robot flange and the gripper configurable.
The fixed joint between the parent link and the coupler is now parameterized via `xyz` and `rpy` parameters in `robotiq_hande_gripper.xacro`.

Resolves the issue in the source repository: https://github.com/macmacal/robotiq_hande_description/issues/8 (a reverse PR must be done afterwards).


## Motivation and context
The default fixed transform assumes a specific flange alignment. On different robot arms or mounting setups, this identity transform may not be valid.  


## How has this been tested?
 In RViz by launching the robot description.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.