### PR TITLE
Fix typo `ip_adress` to `socat_ip_address`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* [PR-15](https://github.com/AGH-CEAI/robotiq_hande_description/pull/15) - Renamed `ip_adress` to `ip_address`.
+
 * [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Updated CMake version from `3.8` to `3.16`; changed ros2_control param name `tty` to `tty_port`.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_address` and `port`.
+* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `socat_ip_address` and `socat_port`.
 
 ### Changed
 
-* [PR-15](https://github.com/AGH-CEAI/robotiq_hande_description/pull/15) - Renamed `ip_adress` to `ip_address`.
+* [PR-15](https://github.com/AGH-CEAI/robotiq_hande_description/pull/15) - Renamed `ip_adress` to `socat_ip_address`.
 
 * [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Updated CMake version from `3.8` to `3.16`; changed ros2_control param name `tty` to `tty_port`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `socat_ip_address` and `socat_port`.
+* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_adress` and `port`.
 
 ### Changed
 
-* [PR-15](https://github.com/AGH-CEAI/robotiq_hande_description/pull/15) - Renamed `ip_adress` to `socat_ip_address`.
+* [PR-15](https://github.com/AGH-CEAI/robotiq_hande_description/pull/15) - Renamed `ip_adress` to `socat_ip_address` and `port` to `socat_port`.
 
 * [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Updated CMake version from `3.8` to `3.16`; changed ros2_control param name `tty` to `tty_port`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_adress` and `port`.
+* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_address` and `port`.
 
 ### Changed
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro
     name="robotiq_hande_ros2_control"
-    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_adress port use_fake_hardware"
+    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_address port use_fake_hardware"
   >
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -24,7 +24,7 @@
           <param name="frequency_hz">${frequency_hz}</param>
 
           <param name="create_socat_tty">${create_socat_tty}</param>
-          <param name="ip_adress">${ip_adress}</param>
+          <param name="ip_address">${ip_address}</param>
           <param name="port">${port}</param>
         </xacro:unless>
       </hardware>

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro
     name="robotiq_hande_ros2_control"
-    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_address port use_fake_hardware"
+    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty socat_ip_address socat_port use_fake_hardware"
   >
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -24,8 +24,8 @@
           <param name="frequency_hz">${frequency_hz}</param>
 
           <param name="create_socat_tty">${create_socat_tty}</param>
-          <param name="ip_address">${ip_address}</param>
-          <param name="port">${port}</param>
+          <param name="socat_ip_address">${socat_ip_address}</param>
+          <param name="socat_port">${port}</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -25,7 +25,7 @@
 
           <param name="create_socat_tty">${create_socat_tty}</param>
           <param name="socat_ip_address">${socat_ip_address}</param>
-          <param name="socat_port">${port}</param>
+          <param name="socat_port">${socat_port}</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -12,7 +12,7 @@
   <xacro:arg name="frequency_hz" default="10"/>
 
   <xacro:arg name="create_socat_tty" default="false"/>
-  <xacro:arg name="ip_adress" default="192.168.100.10"/>
+  <xacro:arg name="ip_address" default="192.168.100.10"/>
   <xacro:arg name="port" default="54321"/>
 
   <xacro:arg name="use_fake_hardware" default="true"/>
@@ -34,7 +34,7 @@
     slave_id="$(arg slave_id)"
     frequency_hz="$(arg frequency_hz)"
     create_socat_tty="$(arg create_socat_tty)"
-    ip_adress="$(arg ip_adress)"
+    ip_address="$(arg ip_address)"
     port="$(arg port)"
     use_fake_hardware="$(arg use_fake_hardware)"
   />

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -12,8 +12,8 @@
   <xacro:arg name="frequency_hz" default="10"/>
 
   <xacro:arg name="create_socat_tty" default="false"/>
-  <xacro:arg name="ip_address" default="192.168.100.10"/>
-  <xacro:arg name="port" default="54321"/>
+  <xacro:arg name="socat_ip_address" default="192.168.100.10"/>
+  <xacro:arg name="socat_port" default="54321"/>
 
   <xacro:arg name="use_fake_hardware" default="true"/>
 
@@ -34,8 +34,8 @@
     slave_id="$(arg slave_id)"
     frequency_hz="$(arg frequency_hz)"
     create_socat_tty="$(arg create_socat_tty)"
-    ip_address="$(arg ip_address)"
-    port="$(arg port)"
+    socat_ip_address="$(arg socat_ip_address)"
+    socat_port="$(arg socat_port)"
     use_fake_hardware="$(arg use_fake_hardware)"
   />
 </robot>

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -23,8 +23,8 @@
             use_fake_hardware
             frequency_hz:=10
             create_socat_tty:=false
-            ip_address:=192.168.100.10
-            port:=54321
+            socat_ip_address:=192.168.100.10
+            socat_port:=54321
             coupler_mass:=0.119
             xyz:='0 0 0'
             rpy:='0 0 0'"
@@ -43,8 +43,8 @@
       slave_id="${slave_id}"
       frequency_hz="${frequency_hz}"
       create_socat_tty="${create_socat_tty}"
-      ip_address="${ip_address}"
-      port="${port}"
+      socat_ip_address="${socat_ip_address}"
+      socat_port="${socat_port}"
       use_fake_hardware="${use_fake_hardware}"
     />
 

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -23,7 +23,7 @@
             use_fake_hardware
             frequency_hz:=10
             create_socat_tty:=false
-            ip_adress:=192.168.100.10
+            ip_address:=192.168.100.10
             port:=54321
             coupler_mass:=0.119
             xyz:='0 0 0'
@@ -43,7 +43,7 @@
       slave_id="${slave_id}"
       frequency_hz="${frequency_hz}"
       create_socat_tty="${create_socat_tty}"
-      ip_adress="${ip_adress}"
+      ip_address="${ip_address}"
       port="${port}"
       use_fake_hardware="${use_fake_hardware}"
     />


### PR DESCRIPTION
## Description
This PR fixes a typo in a variable from `ip_adress` to `socat_ip_address` and `port` to `socat_port`.


## Motivation and context
The typo in the `socat_ip_address` variable was fixed in [PR #23](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/27) in the [robotiq_hande_driver](https://github.com/AGH-CEAI/robotiq_hande_driver) repository. Correcting this ensures consistency and avoids potential runtime errors when specifying the IP address for TCP connections.


## How has this been tested?
Manually, on the Geonosis PC.


## Related PRs
* https://github.com/AGH-CEAI/robotiq_hande_driver/pull/27
* https://github.com/AGH-CEAI/aegis_ros/pull/52


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.

---

Clickup Task: [869a6nn34](https://app.clickup.com/t/869a6nn34)